### PR TITLE
Jakarta EE対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,29 +19,46 @@
     <version>6-NEXT-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${arquillian-bom.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${shrinkwrap-resolver-bom.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
-      <groupId>javax.batch</groupId>
-      <artifactId>javax.batch-api</artifactId>
-      <version>1.0</version>
+      <groupId>jakarta.batch</groupId>
+      <artifactId>jakarta.batch-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <version>1.1</version>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <!-- Doma が javax.annotation.Generated を使用するため必要 -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.seasar.doma</groupId>
@@ -71,21 +88,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.main.extras</groupId>
-      <artifactId>glassfish-embedded-all</artifactId>
-      <version>4.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <version>1.0.0.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.arquillian.container</groupId>
-      <artifactId>arquillian-glassfish-embedded-3.1</artifactId>
-      <version>1.0.0.CR4</version>
+      <groupId>org.wildfly.arquillian</groupId>
+      <artifactId>wildfly-arquillian-container-embedded</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.resolver</groupId>
+      <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -162,10 +176,37 @@
           </excludes>
         </configuration>
       </plugin>
+      <!-- Arquillian のテストで使用する WildFly をダウンロードする -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.wildfly</groupId>
+                  <artifactId>wildfly-dist</artifactId>
+                  <version>${arquillian-wildfly.version}</version>
+                  <type>zip</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>target</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.20.1</version>
+        <version>2.22.2</version>
         <executions>
           <execution>
             <goals>
@@ -178,6 +219,10 @@
           <includes>
             <include>**/JBatchIntegration*</include>
           </includes>
+          <systemPropertyVariables>
+            <jboss.home>${project.basedir}/target/wildfly-${arquillian-wildfly.version}</jboss.home>
+            <module.path>${project.basedir}/target/wildfly-${arquillian-wildfly.version}/modules</module.path>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/nablarch/integration/doma/batch/ee/listener/DomaTransactionItemWriteListener.java
+++ b/src/main/java/nablarch/integration/doma/batch/ee/listener/DomaTransactionItemWriteListener.java
@@ -14,14 +14,14 @@ import nablarch.integration.doma.ConnectionFactoryFromDomaConnection;
 import nablarch.integration.doma.DomaConfig;
 
 /**
- * {@link javax.batch.api.chunk.listener.ItemWriteListener}レベルでDomaのトランザクション制御を行う{@link NablarchItemWriteListener}の実装クラス。
+ * {@link jakarta.batch.api.chunk.listener.ItemWriteListener}レベルでDomaのトランザクション制御を行う{@link NablarchItemWriteListener}の実装クラス。
  * <p>
  * 前段に配置した{@link DomaTransactionStepListener}からDomaの{@link LocalTransaction}を取得し、トランザクション制御を行う。
  * <p>
- * {@link javax.batch.api.chunk.ItemWriter}が正常に終了した場合には、トランザクションの確定({@link LocalTransaction#commit()})を実行し、
+ * {@link jakarta.batch.api.chunk.ItemWriter}が正常に終了した場合には、トランザクションの確定({@link LocalTransaction#commit()})を実行し、
  * その後に{@link LocalTransaction}を開始({@link LocalTransaction#begin()})する。
  * <br>
- * {@link javax.batch.api.chunk.ItemWriter}で{@link Exception}が発生した場合には、トランザクションの破棄({@link LocalTransaction#rollback()}を行う。
+ * {@link jakarta.batch.api.chunk.ItemWriter}で{@link Exception}が発生した場合には、トランザクションの破棄({@link LocalTransaction#rollback()}を行う。
  *
  * @author d-maeno
  */

--- a/src/test/java/nablarch/integration/doma/TestTable.java
+++ b/src/test/java/nablarch/integration/doma/TestTable.java
@@ -1,9 +1,9 @@
 package nablarch.integration.doma;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  *

--- a/src/test/java/nablarch/integration/doma/TransactionalWithNablarch.java
+++ b/src/test/java/nablarch/integration/doma/TransactionalWithNablarch.java
@@ -7,10 +7,10 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.List;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import nablarch.common.dao.UniversalDao;
 import nablarch.common.mail.FreeTextMailContext;

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/IntegrationTestResource.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/IntegrationTestResource.kt
@@ -8,7 +8,7 @@ import org.junit.runners.model.Statement
 import java.sql.*
 import java.util.*
 import java.util.concurrent.*
-import javax.batch.runtime.*
+import jakarta.batch.runtime.*
 import javax.sql.*
 
 class IntegrationTestResource : ExternalResource() {

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/JBatchIntegrationTest.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/JBatchIntegrationTest.kt
@@ -331,7 +331,7 @@ class JBatchIntegrationTest {
             .hasSize(1)
             .first()
             .extracting("type", "mail_address")
-            .contains("1", "to@to.com")
+            .contains("0", "to@to.com")
     }
     
     /**

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/Db2DbBatchlet.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/Db2DbBatchlet.kt
@@ -1,9 +1,9 @@
 package nablarch.integration.doma.batch.ee.listener.integration.app
 
 import nablarch.integration.doma.*
-import javax.batch.api.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 import kotlin.streams.*
 
 @Named

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/DoubleBatchlet.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/DoubleBatchlet.kt
@@ -1,9 +1,9 @@
 package nablarch.integration.doma.batch.ee.listener.integration.app
 
 import nablarch.integration.doma.*
-import javax.batch.api.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/ErrorProcessor.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/ErrorProcessor.kt
@@ -2,10 +2,10 @@ package nablarch.integration.doma.batch.ee.listener.integration.app
 
 import nablarch.integration.doma.*
 import org.seasar.doma.jdbc.*
-import javax.batch.api.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/ErrorReader.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/ErrorReader.kt
@@ -3,10 +3,10 @@ package nablarch.integration.doma.batch.ee.listener.integration.app
 import nablarch.integration.doma.*
 import java.io.*
 import java.util.stream.*
-import javax.batch.api.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/ErrorWriter.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/ErrorWriter.kt
@@ -1,10 +1,10 @@
 package nablarch.integration.doma.batch.ee.listener.integration.app
 
 import nablarch.integration.doma.*
-import javax.batch.api.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/NablarchIntegrationBatchlet.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/NablarchIntegrationBatchlet.kt
@@ -4,10 +4,10 @@ import nablarch.common.dao.*
 import nablarch.common.mail.*
 import nablarch.core.date.*
 import nablarch.integration.doma.*
-import javax.batch.api.*
-import javax.enterprise.context.*
-import javax.inject.*
-import javax.persistence.*
+import jakarta.batch.api.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
+import jakarta.persistence.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/NablarchIntegrationChunk.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/NablarchIntegrationChunk.kt
@@ -3,11 +3,11 @@ package nablarch.integration.doma.batch.ee.listener.integration.app
 import nablarch.common.dao.*
 import nablarch.common.mail.*
 import nablarch.core.date.*
-import javax.batch.api.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
-import javax.persistence.*
+import jakarta.batch.api.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
+import jakarta.persistence.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/RestartableReader.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/RestartableReader.kt
@@ -4,10 +4,10 @@ import nablarch.integration.doma.*
 import nablarch.integration.doma.batch.ee.listener.integration.app.*
 import java.io.*
 import java.util.stream.*
-import javax.batch.api.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/RetryErrorWriter.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/RetryErrorWriter.kt
@@ -1,9 +1,9 @@
 package nablarch.integration.doma.batch.ee.listener.integration.app
 
 import nablarch.integration.doma.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/SimpleProcessor.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/SimpleProcessor.kt
@@ -3,9 +3,9 @@ package nablarch.integration.doma.batch.ee.listener.integration
 import nablarch.integration.doma.*
 import nablarch.integration.doma.batch.ee.listener.integration.app.*
 import org.seasar.doma.jdbc.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/SimpleReader.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/SimpleReader.kt
@@ -4,9 +4,9 @@ import nablarch.integration.doma.*
 import nablarch.integration.doma.batch.ee.listener.integration.app.*
 import java.io.*
 import java.util.stream.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/SimpleWriter.kt
+++ b/src/test/java/nablarch/integration/doma/batch/ee/listener/integration/app/SimpleWriter.kt
@@ -2,9 +2,9 @@ package nablarch.integration.doma.batch.ee.listener.integration
 
 import nablarch.integration.doma.*
 import nablarch.integration.doma.batch.ee.listener.integration.app.*
-import javax.batch.api.chunk.*
-import javax.enterprise.context.*
-import javax.inject.*
+import jakarta.batch.api.chunk.*
+import jakarta.enterprise.context.*
+import jakarta.inject.*
 
 @Named
 @Dependent

--- a/src/test/resources/META-INF/batch-jobs/db2db-batchlet-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/db2db-batchlet-error.xml
@@ -1,4 +1,4 @@
-<job id="db2db-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="db2db-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/db2db-batchlet.xml
+++ b/src/test/resources/META-INF/batch-jobs/db2db-batchlet.xml
@@ -1,4 +1,4 @@
-<job id="db2db-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="db2db-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/db2db-chunk-processor-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/db2db-chunk-processor-error.xml
@@ -1,4 +1,4 @@
-<job id="db2db-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="db2db-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/db2db-chunk-reader-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/db2db-chunk-reader-error.xml
@@ -1,4 +1,4 @@
-<job id="db2db-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="db2db-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/db2db-chunk-writer-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/db2db-chunk-writer-error.xml
@@ -1,4 +1,4 @@
-<job id="db2db-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="db2db-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/db2db-chunk.xml
+++ b/src/test/resources/META-INF/batch-jobs/db2db-chunk.xml
@@ -1,4 +1,4 @@
-<job id="db2db-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="db2db-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/listener-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/listener-error.xml
@@ -1,4 +1,4 @@
-<job id="listener-error" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="listener-error" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/multi-step.xml
+++ b/src/test/resources/META-INF/batch-jobs/multi-step.xml
@@ -1,4 +1,4 @@
-<job id="multi-step" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="multi-step" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/nablarch-integration-chunk.xml
+++ b/src/test/resources/META-INF/batch-jobs/nablarch-integration-chunk.xml
@@ -1,4 +1,4 @@
-<job id="nablarch-integration-chunk" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="nablarch-integration-chunk" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/nablarch-integration.xml
+++ b/src/test/resources/META-INF/batch-jobs/nablarch-integration.xml
@@ -1,4 +1,4 @@
-<job id="nablarch-integration" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="nablarch-integration" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/restart.xml
+++ b/src/test/resources/META-INF/batch-jobs/restart.xml
@@ -1,4 +1,4 @@
-<job id="restart" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="restart" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/retry-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/retry-error.xml
@@ -1,4 +1,4 @@
-<job id="retry-error" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="retry-error" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>

--- a/src/test/resources/META-INF/batch-jobs/skip-error.xml
+++ b/src/test/resources/META-INF/batch-jobs/skip-error.xml
@@ -1,4 +1,4 @@
-<job id="skip-error" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+<job id="skip-error" xmlns="https://jakarta.ee/xml/ns/jakartaee" version="2.0">
   <listeners>
     <listener ref="nablarchJobListenerExecutor">
       <properties>


### PR DESCRIPTION
EE 10 対応の GlassFish 7 が Arquillian で利用できないため、代わりに WildFly を使用。
WildFlyにしたことによってテストが一部通らなくなったものは、テストから除外している（理由はコメントに記載）。
