### PR TITLE
CI環境でConfigのテストが失敗するため対応

### DIFF
--- a/src/test/java/nablarch/integration/doma/DomaTransactionNotSupportedConfigTest.java
+++ b/src/test/java/nablarch/integration/doma/DomaTransactionNotSupportedConfigTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -35,12 +36,16 @@ public class DomaTransactionNotSupportedConfigTest {
     /**
      * システムリポジトリに定義したダイアレクトが取得できること。
      *
+     * <p>Configオブジェクトの初期化タイミングがクラスロード時であり、
+     * 本テストクラスの前処理で設定したシステムリポジトリの状態で初期化される保証が無いため、
+     * 明示的に生成した結果から検証する。（以降のテストも同様）
+     *
      * @throws Exception
      */
     @Test
     public void getDialect() throws Exception {
-        Dialect dialect = DomaTransactionNotSupportedConfig.singleton()
-                                                           .getDialect();
+        DomaTransactionNotSupportedConfig config = ReflectionUtil.newInstance(DomaTransactionNotSupportedConfig.class);
+        Dialect dialect = config.getDialect();
         assertThat(dialect)
                   .isInstanceOf(H2Dialect.class);
     }
@@ -52,8 +57,8 @@ public class DomaTransactionNotSupportedConfigTest {
      */
     @Test
     public void getDataSource() throws Exception {
-        DataSource dataSource = DomaTransactionNotSupportedConfig.singleton()
-                                                                 .getDataSource();
+        DomaTransactionNotSupportedConfig config = ReflectionUtil.newInstance(DomaTransactionNotSupportedConfig.class);
+        DataSource dataSource = config.getDataSource();
         assertThat(dataSource)
                   .isInstanceOf(BasicDataSource.class);
     }
@@ -65,9 +70,8 @@ public class DomaTransactionNotSupportedConfigTest {
      */
     @Test
     public void getTransactionManager() throws Exception {
-
-        assertThatThrownBy(() -> DomaTransactionNotSupportedConfig.singleton()
-                                                                             .getTransactionManager())
+        DomaTransactionNotSupportedConfig config = ReflectionUtil.newInstance(DomaTransactionNotSupportedConfig.class);
+        assertThatThrownBy(config::getTransactionManager)
                   .isInstanceOf(UnsupportedOperationException.class)
         ;
     }
@@ -79,8 +83,8 @@ public class DomaTransactionNotSupportedConfigTest {
      */
     @Test
     public void getNaming() throws Exception {
-        Naming naming = DomaTransactionNotSupportedConfig.singleton()
-                                                         .getNaming();
+        DomaTransactionNotSupportedConfig config = ReflectionUtil.newInstance(DomaTransactionNotSupportedConfig.class);
+        Naming naming = config.getNaming();
         assertThat(naming)
                   .isEqualTo(Naming.SNAKE_UPPER_CASE);
     }
@@ -121,7 +125,8 @@ public class DomaTransactionNotSupportedConfigTest {
      */
     @Test
     public void getJdbcLogger() {
-        JdbcLogger jdbcLogger = DomaTransactionNotSupportedConfig.singleton().getJdbcLogger();
+        DomaTransactionNotSupportedConfig config = ReflectionUtil.newInstance(DomaTransactionNotSupportedConfig.class);
+        JdbcLogger jdbcLogger = config.getJdbcLogger();
         assertThat(jdbcLogger, instanceOf(UtilLoggingJdbcLogger.class));
     }
 
@@ -140,7 +145,7 @@ public class DomaTransactionNotSupportedConfigTest {
      */
     @Test
     public void getStatementProperties() {
-        DomaTransactionNotSupportedConfig config = DomaTransactionNotSupportedConfig.singleton();
+        DomaTransactionNotSupportedConfig config = ReflectionUtil.newInstance(DomaTransactionNotSupportedConfig.class);
         assertThat(config.getMaxRows(), is(1000));
         assertThat(config.getFetchSize(), is(200));
         assertThat(config.getQueryTimeout(), is(30));
@@ -158,5 +163,17 @@ public class DomaTransactionNotSupportedConfigTest {
         assertThat(config.getFetchSize(), is(0));
         assertThat(config.getQueryTimeout(), is(0));
         assertThat(config.getBatchSize(), is(0));
+    }
+
+    /**
+     * 初期化されたConfigオブジェクトを取得できること。
+     *
+     * <p>Configオブジェクトの初期化タイミングがクラスロード時であり、
+     * 本テストクラスの前処理で設定したシステムリポジトリの状態で初期化される保証が無いため、
+     * 初期化によりオブジェクトが設定されていることのみ検証する。
+     */
+    @Test
+    public void getSingletonObject() {
+        assertNotNull(DomaTransactionNotSupportedConfig.singleton());
     }
 }


### PR DESCRIPTION
## 背景

CI環境でテスト実行時、以下の内容でテストが失敗している。

```
[ERROR] Tests run: 10, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.356 s <<< FAILURE! - in nablarch.integration.doma.DomaTransactionNotSupportedConfigTest
[ERROR] getJdbcLogger(nablarch.integration.doma.DomaTransactionNotSupportedConfigTest)  Time elapsed: 0.014 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: an instance of org.seasar.doma.jdbc.UtilLoggingJdbcLogger
     but: <nablarch.integration.doma.NablarchJdbcLogger@1fbdc053> is a nablarch.integration.doma.NablarchJdbcLogger
	at nablarch.integration.doma.DomaTransactionNotSupportedConfigTest.getJdbcLogger(DomaTransactionNotSupportedConfigTest.java:125)

[ERROR] getDataSource(nablarch.integration.doma.DomaTransactionNotSupportedConfigTest)  Time elapsed: 0.105 s  <<< FAILURE!
java.lang.AssertionError: 

Expecting:
 <ds13: url=jdbc:h2:mem:ssd;LOCK_TIMEOUT=15000;DB_CLOSE_DELAY=-1 user=sa>
to be an instance of:
 <org.apache.commons.dbcp.BasicDataSource>
but was instance of:
 <org.h2.jdbcx.JdbcDataSource>
	at nablarch.integration.doma.DomaTransactionNotSupportedConfigTest.getDataSource(DomaTransactionNotSupportedConfigTest.java:58)

[ERROR] getStatementProperties(nablarch.integration.doma.DomaTransactionNotSupportedConfigTest)  Time elapsed: 0.035 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: is <1000>
     but: was <0>
	at nablarch.integration.doma.DomaTransactionNotSupportedConfigTest.getStatementProperties(DomaTransactionNotSupportedConfigTest.java:144)
```

## 原因

`DomaTransactionNotSupportedConfig`はクラスロード時に初期化され、そのタイミングでシステムリポジトリからコンポーネントを取得しているが、そこで設定された状態が想定どおりになっていないためテストに失敗している。

テストクラス毎にコンポーネント定義ファイルを指定してシステムリポジトリを再ロードしているが、上記の理由によりConfigオブジェクトは再作成されないため、Configオブジェクトの状態はテストクラスの実行順序とロードタイミングに依存している。そのため、おそらくテストクラスの実行順序に依存して、想定したシステムリポジトリの状態で初期化されなかったものだと思われる。

## 対応

クラスロード時の初期化を任意で行うことはできないため、オブジェクト生成時の状態設定とロード時の初期化は分けて検証することにした。