### PR TITLE
H2のバージョンを2.2.220に更新しました

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.1.214</version>
+      <version>2.2.220</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-doma-adaptor/pull/27
の対応